### PR TITLE
Remove macro typedef in order to manually define type as a union of the members

### DIFF
--- a/lib/enum_type.ex
+++ b/lib/enum_type.ex
@@ -15,8 +15,6 @@ defmodule EnumType do
   defmacro defenum(name, ecto_type, do: block) do
     quote do
       defmodule unquote(name) do
-        @type t :: __MODULE__
-
         Module.register_attribute(__MODULE__, :possible_options, accumulate: true)
 
         if Code.ensure_compiled?(Ecto.Type) do

--- a/test/enum_test.exs
+++ b/test/enum_test.exs
@@ -33,7 +33,6 @@ defmodule EnumTypeTest do
     end
     default One
 
-    @spec hello(CustomSample.t) :: String.t
     def hello(enum), do: "Hello #{enum.value}"
   end
 


### PR DESCRIPTION
current behaviour

```elixir
defenum Colors do
  value Red, "red"
  value Blue, "blue"
end
```
=> `Colors.t()  :: Colors`

desired behaviour

```elixir
defenum Colors do
  value Red, "red"
  value Blue, "blue"
end
```
=> `Colors.t() :: Red | Blue`

It would be best to handle this in the macro, but for now, we can be content with just defining the typespec manually:

```elixir
defenum Colors do
  value Red, "red"
  value Blue, "blue"

  @type t :: Red | Blue
end
```