### PR TITLE
Remove macro typedef in order to manually define type as a union of t…

### DIFF
--- a/lib/enum_type.ex
+++ b/lib/enum_type.ex
@@ -15,8 +15,6 @@ defmodule EnumType do
   defmacro defenum(name, ecto_type, do: block) do
     quote do
       defmodule unquote(name) do
-        @type t :: __MODULE__
-
         Module.register_attribute(__MODULE__, :possible_options, accumulate: true)
 
         if Code.ensure_compiled?(Ecto.Type) do

--- a/test/enum_test.exs
+++ b/test/enum_test.exs
@@ -33,7 +33,6 @@ defmodule EnumTypeTest do
     end
     default One
 
-    @spec hello(CustomSample.t) :: String.t
     def hello(enum), do: "Hello #{enum.value}"
   end
 


### PR DESCRIPTION
## Current behaviour:

```elixir
defenum Colors do
  value Red, "red"
  value Blue, "blue"
end
```
=> `Colors.t() :: Colors`

## Desired behaviour:

```elixir
defenum Colors do
  value Red, "red"
  value Blue, "blue"
end
```
=> `Colors.t() :: Colors.Red | Colors.Blue`

Ideally, the macros would generate the union type for us, but for now, doing it manually is fine.  In order to do that, we need to remove the existing generated typedef.

## Possible after this PR:

```elixir
defenum Colors do
  value Red, "red"
  value Blue, "blue"

  @type t :: Red | Blue
end
```
=> `Colors.t() :: Colors.Red | Colors.Blue`